### PR TITLE
Fix a couple of linting warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/centos/centos:stream9 AS builder
-RUN dnf install git golang -y
+RUN dnf install git golang -y && dnf clean all
 RUN go version
 
 

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -20,4 +20,4 @@ case $1 in
     "run") EXTRA="run";;
     *)	EXTRA="build -o manager";;
 esac
-GOFLAGS=-mod=vendor CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go $EXTRA -ldflags="${LDFLAGS}" main.go
+GOFLAGS=-mod=vendor CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go "${EXTRA}" -ldflags="${LDFLAGS}" main.go


### PR DESCRIPTION
1)
In /github/workspace/hack/build.sh line 23:
GOFLAGS=-mod=vendor CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go $EXTRA -ldflags="${LDFLAGS}" main.go
                                                             ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

2)

2022-02-23 12:35:10 [INFO]   File:[/github/workspace/Dockerfile]
2022-02-23 12:35:10 [ERROR]   Found errors in [hadolint] linter!
2022-02-23 12:35:10 [ERROR]   Error code: 1. Command output:
------
/github/workspace/Dockerfile:2 DL3040 warning: `dnf clean all` missing after dnf command.
