### PR TITLE
Add dnf clean all in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/centos/centos:stream9 AS builder
-RUN dnf install git golang -y
+RUN dnf install git golang -y && dnf clean all
 RUN go version
 
 


### PR DESCRIPTION
Fixes the following linter:

  2022-02-23 12:35:10 [INFO]   File:[/github/workspace/Dockerfile]
  2022-02-23 12:35:10 [ERROR]   Found errors in [hadolint] linter!
  2022-02-23 12:35:10 [ERROR]   Error code: 1. Command output:
  ------
  /github/workspace/Dockerfile:2 DL3040 warning: `dnf clean all` missing after dnf command.

This will keep one of the image layers a bit smaller
