### PR TITLE
Add RBAC to allow listing/getting infrastructures

### DIFF
--- a/bundle/manifests/patterns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/patterns-operator.clusterserviceversion.yaml
@@ -129,6 +129,13 @@ spec:
         - apiGroups:
           - config.openshift.io
           resources:
+          - infrastructures
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - config.openshift.io
+          resources:
           - ingresses
           verbs:
           - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -34,6 +34,13 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - infrastructures
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - config.openshift.io
+  resources:
   - ingresses
   verbs:
   - get

--- a/controllers/pattern_controller.go
+++ b/controllers/pattern_controller.go
@@ -66,6 +66,7 @@ type PatternReconciler struct {
 //+kubebuilder:rbac:groups=gitops.hybrid-cloud-patterns.io,resources=patterns/finalizers,verbs=update
 //+kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=list;get
 //+kubebuilder:rbac:groups=config.openshift.io,resources=ingresses,verbs=list;get
+//+kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=list;get
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=list;get
 //+kubebuilder:rbac:groups=argoproj.io,resources=applications,verbs=list;get;create;update;patch;delete
 //+kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions,verbs=list;get;create;update;patch;delete


### PR DESCRIPTION
On my local workstation reploy I was getting the following error:

    Reconcile step "applying defaults" failed:
      infrastructures.config.openshift.io "cluster" is forbidden: User
      "system:serviceaccount:openshift-operators:patterns-operator-controller-manager"
      cannot get resource "infrastructures" in API group "config.openshift.io" at the cluster scope

In controllers/pattern_controller.go we do the following:

    clusterInfra, err := r.configClient.ConfigV1().Infrastructures().Get(context.Background(), "cluster", metav1.GetOptions{})

Not sure why this has been seen only now on my local 4.9 cluster though?. Need
to investigate some more before merging, hence the WIP
