### PR TITLE
When installing via UI make sure we default to our own 'patterns-operator-system' namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ The subscription and anything created by Argo will not be removed and canmust be
 Removing the top-level application ensures that Argo won't try to put back anything you delete.
 
 ## Watch the logs
-Note that when installing via UI the namespace will be `openshift-operators` and not `patterns-operator-system`
 ```
 oc logs -npatterns-operator-system `oc get -npatterns-operator-system pods -o name --field-selector status.phase=Running | grep patterns` -c manager -f
 ```

--- a/bundle/manifests/patterns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/patterns-operator.clusterserviceversion.yaml
@@ -22,6 +22,7 @@ metadata:
     categories: OpenShift Optional
     containerImage: quay.io/hybridcloudpatterns/patterns-operator:0.0.2
     description: An operator to deploy and manage architecture patterns from https://hybrid-cloud-patterns.io
+    operatorframework.io/suggested-namespace: patterns-operator-system
     operators.operatorframework.io/builder: operator-sdk-v1.19.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/hybrid-cloud-patterns/patterns-operator

--- a/config/manifests/bases/patterns-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/patterns-operator.clusterserviceversion.yaml
@@ -7,6 +7,7 @@ metadata:
     categories: OpenShift Optional
     containerImage: quay.io/hybridcloudpatterns/patterns-operator:0.0.1
     description: An operator to deploy and manage architecture patterns from https://hybrid-cloud-patterns.io
+    operatorframework.io/suggested-namespace: patterns-operator-system
     repository: https://github.com/hybrid-cloud-patterns/patterns-operator
   name: patterns-operator.v0.0.0
   namespace: placeholder


### PR DESCRIPTION
Currently it picks `openshift-operators` when installing via UI, which
is different when installing via CLI which picks
`patterns-operator-system`.

By adding the `operatorframework.io/suggested-namespace` annotation we
instruct OLM to default to patterns-operator-system (OLM will create the
namespace for us)

Tested and now I can install the operator via the OperatorHub UI and get
it correctly installed in the patterns-operator-system:

  oc get pods -A | grep -i pattern
  patterns-operator-system                           patterns-operator-controller-manager-74b84b46bb-mf6lt             2/2     Running     0              17m
