### PR TITLE
use logOnce() for Insecure Vault message

### DIFF
--- a/controllers/pattern_controller.go
+++ b/controllers/pattern_controller.go
@@ -194,7 +194,7 @@ func (r *PatternReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 	// Unseal the vault
 	if *qualifiedInstance.Spec.InsecureManagedVault {
-		log.Printf("Insecure Vault set to true")
+		logOnce("Insecure Vault set to true")
 		if initialized, err := vaultInitialize(r.config, r.fullClient); err != nil || initialized {
 			return r.actionPerformed(qualifiedInstance, "Initialize vault", err)
 		}


### PR DESCRIPTION
This avoid a bunch of excess logging that brings very little.
