### PR TITLE
Switch to git-core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal AS builder
-RUN microdnf install git golang -y && microdnf clean all
+RUN microdnf install git-core golang -y && microdnf clean all
 #
 # Until ubi has golang 1.17
 #FROM golang:1.17-alpine as builder


### PR DESCRIPTION
The "git" package adds some unneeded commands:
/usr/libexec/git-core/git-add--interactive
/usr/libexec/git-core/git-contacts
/usr/libexec/git-core/git-credential-netrc
/usr/libexec/git-core/git-filter-branch
/usr/libexec/git-core/git-request-pull

These are almost never needed and bring in a bunch of perl and
emacs-filesystem dependencies. Let's just stick to git-core
which contains all the commands we need.
