### PR TITLE
Fix nil dereference bug

### DIFF
--- a/controllers/pattern_controller.go
+++ b/controllers/pattern_controller.go
@@ -332,7 +332,7 @@ func (r *PatternReconciler) finalizeObject(instance *api.Pattern) error {
 
 		_, app := getApplication(r.argoClient, applicationName(*qualifiedInstance))
 		if app == nil {
-			log.Printf("Application %q has already been removed\n", app.Name)
+			log.Printf("Application has already been removed\n")
 			return nil
 		}
 


### PR DESCRIPTION
When calling finalizeObject() we can potentially trigger the following
bug:

  2022/07/11 19:06:03 Finalizing pattern object⤶ 20 panic: runtime error: invalid memory address or nil pointer dereference⤶ 21 [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1ae27ce]⤶ 22 ⤶
  goroutine 363 [running]:⤶ 24 github.com/hybrid-cloud-patterns/patterns-operator/controllers.(*PatternReconciler).finalizeObject(0xc0004c2500, 0x22bcd88)⤶ 25 ··/workspace/controllers/pattern_controller.go:358 +0x52e⤶ 26 github.com/hybrid-cloud-patterns/patterns-operator/controllers.(*PatternReconciler).Reconcile(0xc0004c2500, {0x22bcdf8, 0xc0006bdaa0}, {{{0xc0004e5da0, 0x1ed24e0}, {0xc000b12d40, 0x30}}})⤶ 27 ··/workspace/controllers/pattern_controller.go:129 +0xe0a⤶ 28 sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0xc000a0f4a0, {0x22bcdf8, 0xc0006bd9e0}, {{{0xc0004e5da0, 0x1ed24e0}, {0xc000b12d40, 0x413894}}})⤶
  ··/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114 +0x26f⤶
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000a0f4a0, {0x22bcd50, 0xc00082a600}, {0x1daee00, 0xc00043c7e0})⤶
  ··/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311 +0x33e⤶
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000a0f4a0, {0x22bcd50, 0xc00082a600})⤶
  ··/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266 +0x205⤶
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()⤶
  ··/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227 +0x85⤶
  created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2⤶
··/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:223 +0x357⤶

This is because we had the following code:
  _, app := getApplication(r.argoClient, applicationName(*qualifiedInstance))
  if app == nil {
    log.Printf("Application %q has already been removed\n", app.Name)
      return nil
  }

At that point if app is nil we cannot inspect it, so let's just print a
generic message
