### PR TITLE
Revert "When installing via UI make sure we default to our own 'patterns-operator-system' namespace"

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The subscription and anything created by Argo will not be removed and canmust be
 Removing the top-level application ensures that Argo won't try to put back anything you delete.
 
 ## Watch the logs
+Note that when installing via UI the namespace will be `openshift-operators` and not `patterns-operator-system`
 ```
 oc logs -npatterns-operator-system `oc get -npatterns-operator-system pods -o name --field-selector status.phase=Running | grep patterns` -c manager -f
 ```

--- a/bundle/manifests/patterns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/patterns-operator.clusterserviceversion.yaml
@@ -22,7 +22,6 @@ metadata:
     categories: OpenShift Optional
     containerImage: quay.io/hybridcloudpatterns/patterns-operator:0.0.4
     description: An operator to deploy and manage architecture patterns from https://hybrid-cloud-patterns.io
-    operatorframework.io/suggested-namespace: patterns-operator-system
     operators.operatorframework.io/builder: operator-sdk-v1.22.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/hybrid-cloud-patterns/patterns-operator

--- a/config/manifests/bases/patterns-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/patterns-operator.clusterserviceversion.yaml
@@ -7,7 +7,6 @@ metadata:
     categories: OpenShift Optional
     containerImage: quay.io/hybridcloudpatterns/patterns-operator:0.0.1
     description: An operator to deploy and manage architecture patterns from https://hybrid-cloud-patterns.io
-    operatorframework.io/suggested-namespace: patterns-operator-system
     repository: https://github.com/hybrid-cloud-patterns/patterns-operator
   name: patterns-operator.v0.0.0
   namespace: placeholder


### PR DESCRIPTION
This reverts commit 29fb6f0671bb58ec56cbb0918bb098a98f086a5b.

It seems OLM's general direction is to want the initial namespace of an
operator to be 'openshift-operators'

This will leave us with a discrepancy between installing with the UI
and installing the operator via a rebuild and 'make deploy' but so be
it.
