### PR TITLE
[WIP] Add apiServerURL variable

### DIFF
--- a/api/v1alpha1/pattern_types.go
+++ b/api/v1alpha1/pattern_types.go
@@ -148,6 +148,8 @@ type PatternStatus struct {
 	ClusterID string `json:"clusterID,omitempty"`
 	//+operator-sdk:csv:customresourcedefinitions:type=status
 	ClusterPlatform string `json:"clusterPlatform,omitempty"`
+	//+operator-sdk:csv:customresourcedefinitions:type=status
+	ClusterApiServerURL string `json:"clusterApiServerUrl,omitempty"`
 }
 
 // See: https://book.kubebuilder.io/reference/markers/crd.html

--- a/controllers/argo.go
+++ b/controllers/argo.go
@@ -66,6 +66,10 @@ func newApplicationParameters(p api.Pattern) []argoapi.HelmParameter {
 			Name:  "global.localClusterName",
 			Value: p.Status.ClusterName,
 		},
+		{
+			Name:  "global.clusterApiServerURL",
+			Value: p.Status.ClusterApiServerURL,
+		},
 	}
 
 	for _, extra := range p.Spec.ExtraParameters {

--- a/controllers/pattern_controller.go
+++ b/controllers/pattern_controller.go
@@ -267,6 +267,7 @@ func (r *PatternReconciler) applyDefaults(input *api.Pattern) (error, *api.Patte
 		//      type: AWS
 
 		output.Status.ClusterPlatform = string(clusterInfra.Spec.PlatformSpec.Type)
+		output.Status.ClusterApiServerURL = clusterInfra.Status.APIServerURL
 	}
 
 	// Derive cluster and domain names


### PR DESCRIPTION
global.clusterApiServerURL is the variable that will point to the API
url:
apiVersion: config.openshift.io/v1
kind: Infrastructure
metadata:
	name: cluster
	resourceVersion: '598'
	uid: 671a2ba8-f3ef-47cb-b7e0-06a71235bf92
spec:
	cloudConfig:
		name: ''
	platformSpec:
		aws: {}
		type: AWS
status:
	apiServerInternalURI: 'https://api-int.mcg-hub.blueprints.rhecoeng.com:6443'
	apiServerURL: 'https://api.mcg-hub.blueprints.rhecoeng.com:6443'
