### PR TITLE
Make /values-<platform>.yaml dependent on the clustergroup as well

### DIFF
--- a/controllers/argo.go
+++ b/controllers/argo.go
@@ -96,7 +96,7 @@ func newApplicationValueFiles(p api.Pattern) []string {
 	files := []string{
 		"/values-global.yaml",
 		fmt.Sprintf("/values-%s.yaml", p.Spec.ClusterGroupName),
-		fmt.Sprintf("/values-%s.yaml", p.Status.ClusterPlatform),
+		fmt.Sprintf("/values-%s-%s.yaml", p.Status.ClusterPlatform, p.Spec.ClusterGroupName),
 		fmt.Sprintf("/values-%s-%s.yaml", p.Status.ClusterVersion, p.Spec.ClusterGroupName),
 		fmt.Sprintf("/values-%s.yaml", p.Status.ClusterName),
 	}


### PR DESCRIPTION
Currently in the operator we add /values-AWS.yaml (or whatever platform
OCP is running on) on the cluster-wide argo instance on the hub.

To make this a bit more useful, and in the same vein as common PR#191
we actually include /values-<platform>-<clustergroup>.yaml

We can do this breaking change because this platform support is
currently partial and this include is not propagated to the argo apps on
the hub nor on the spokes anyways.

With this change a user could have a Multicloud Gitops installation and
user the following overrides:
/values-AWS-hub.yaml - Specific for the hub running on AWS
/values-GCP-spoke1.yaml - Specific for clustergroup spoke1 running on GCP
/values-AWS-spoke2.yaml - Specific for clustergroup spoke2 running on AWS
