### PR TITLE
Actually pass the clusterPlatform down to argo

### DIFF
--- a/controllers/argo.go
+++ b/controllers/argo.go
@@ -67,6 +67,10 @@ func newApplicationParameters(p api.Pattern) []argoapi.HelmParameter {
 			Value: p.Status.ClusterVersion,
 		},
 		{
+			Name:  "global.clusterPlatform",
+			Value: p.Status.ClusterPlatform,
+		},
+		{
 			Name:  "global.localClusterName",
 			Value: p.Status.ClusterName,
 		},


### PR DESCRIPTION
So it can be reused by the namespaced argo and all the other charts.
Tested this with a common/ PR and was abloe to get the right variable
down to all charts (cluster-wide and namespaced argos both)
