### PR TITLE
Fix subscription update

### DIFF
--- a/controllers/subscription.go
+++ b/controllers/subscription.go
@@ -103,9 +103,9 @@ func createSubscription(client olmclient.Interface, sub *operatorv1alpha1.Subscr
 
 func updateSubscription(client olmclient.Interface, target, current *operatorv1alpha1.Subscription) (error, bool) {
 	changed := false
-	if current == nil || current.Spec != nil {
+	if current == nil || current.Spec == nil {
 		return fmt.Errorf("current subscription was nil"), false
-	} else if target == nil || target.Spec != nil {
+	} else if target == nil || target.Spec == nil {
 		return fmt.Errorf("target subscription was nil"), false
 	}
 


### PR DESCRIPTION
Currently if a user changes the subscription after the initial pattern
deployment (by tweaking gitOpsSpec.operatorChannel) the subscription
won't be updated. Reason for this are the wrong != nil comparisons
of target.Spec and current.Spec, which will always be true and so
updateSubscription() becomes a noop.

Fix the nil check so that updateSubscription does its job.

Tested on MCG and was able to correctly upgrade gitops from stable to
latest.

Fixes: MBP-351
