### PR TITLE
Add extra platform overrides

### DIFF
--- a/controllers/argo.go
+++ b/controllers/argo.go
@@ -100,6 +100,8 @@ func newApplicationValueFiles(p api.Pattern) []string {
 	files := []string{
 		"/values-global.yaml",
 		fmt.Sprintf("/values-%s.yaml", p.Spec.ClusterGroupName),
+		fmt.Sprintf("/values-%s.yaml", p.Status.ClusterPlatform),
+		fmt.Sprintf("/values-%s-%s.yaml", p.Status.ClusterPlatform, p.Status.ClusterVersion),
 		fmt.Sprintf("/values-%s-%s.yaml", p.Status.ClusterPlatform, p.Spec.ClusterGroupName),
 		fmt.Sprintf("/values-%s-%s.yaml", p.Status.ClusterVersion, p.Spec.ClusterGroupName),
 		fmt.Sprintf("/values-%s.yaml", p.Status.ClusterName),


### PR DESCRIPTION
Add a global platform values-<platform>.yaml and a
values-<platform>-<clusterversion>.yaml override.

This allows us to be a bit less verbose and have per-cloud global
overrides and also still cater for silly things like ODF in Azure:

The storage class for ODF in Azure needs to be X when OCP <= 4.10
and it needs to be Y when OCP > 4.11.

With this patch (and its common/ counterpart) a user could do the
following:
./values-Azure.yaml # Default for late versions of OCP on Azure
./values-Azure-4.9.yaml
./values-Azure-4.10.yaml
