### PR TITLE
Switch to gitop-1.8 channel by default

### DIFF
--- a/api/v1alpha1/pattern_types.go
+++ b/api/v1alpha1/pattern_types.go
@@ -111,7 +111,7 @@ const (
 )
 
 type GitOpsConfig struct {
-	// Channel to deploy openshift-gitops from. Default: stable
+	// Channel to deploy openshift-gitops from. Default: gitops-1.8
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	OperatorChannel string `json:"operatorChannel,omitempty"`
 	// Source to deploy openshift-gitops from. Default: redhat-operators

--- a/bundle/manifests/gitops.hybrid-cloud-patterns.io_patterns.yaml
+++ b/bundle/manifests/gitops.hybrid-cloud-patterns.io_patterns.yaml
@@ -82,7 +82,7 @@ spec:
                     type: string
                   operatorChannel:
                     description: 'Channel to deploy openshift-gitops from. Default:
-                      stable'
+                      gitops-1.8'
                     type: string
                   operatorSource:
                     description: 'Source to deploy openshift-gitops from. Default:

--- a/bundle/manifests/patterns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/patterns-operator.clusterserviceversion.yaml
@@ -64,7 +64,7 @@ spec:
       - description: Specific version of openshift-gitops to deploy.  Requires UseCSV=True
         displayName: Operator CSV
         path: gitOpsSpec.operatorCSV
-      - description: 'Channel to deploy openshift-gitops from. Default: stable'
+      - description: 'Channel to deploy openshift-gitops from. Default: gitops-1.8'
         displayName: Operator Channel
         path: gitOpsSpec.operatorChannel
       - description: 'Source to deploy openshift-gitops from. Default: redhat-operators'

--- a/config/crd/bases/gitops.hybrid-cloud-patterns.io_patterns.yaml
+++ b/config/crd/bases/gitops.hybrid-cloud-patterns.io_patterns.yaml
@@ -84,7 +84,7 @@ spec:
                     type: string
                   operatorChannel:
                     description: 'Channel to deploy openshift-gitops from. Default:
-                      stable'
+                      gitops-1.8'
                     type: string
                   operatorSource:
                     description: 'Source to deploy openshift-gitops from. Default:

--- a/config/manifests/bases/patterns-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/patterns-operator.clusterserviceversion.yaml
@@ -46,7 +46,7 @@ spec:
       - description: Specific version of openshift-gitops to deploy.  Requires UseCSV=True
         displayName: Operator CSV
         path: gitOpsSpec.operatorCSV
-      - description: 'Channel to deploy openshift-gitops from. Default: stable'
+      - description: 'Channel to deploy openshift-gitops from. Default: gitops-1.8'
         displayName: Operator Channel
         path: gitOpsSpec.operatorChannel
       - description: 'Source to deploy openshift-gitops from. Default: redhat-operators'

--- a/controllers/pattern_controller.go
+++ b/controllers/pattern_controller.go
@@ -361,7 +361,7 @@ func (r *PatternReconciler) applyDefaults(input *api.Pattern) (error, *api.Patte
 	}
 
 	if len(output.Spec.GitOpsConfig.OperatorChannel) == 0 {
-		output.Spec.GitOpsConfig.OperatorChannel = "stable"
+		output.Spec.GitOpsConfig.OperatorChannel = "gitops-1.8"
 	}
 
 	if len(output.Spec.GitOpsConfig.OperatorSource) == 0 {

--- a/controllers/subscription.go
+++ b/controllers/subscription.go
@@ -43,7 +43,7 @@ func newSubscription(p api.Pattern) *operatorv1alpha1.Subscription {
 	//    name: openshift-gitops-operator
 	//    namespace: openshift-operators
 	//  spec:
-	//    channel: stable
+	//    channel: v1.8.x
 	//    installPlanApproval: Automatic
 	//    name: openshift-gitops-operator
 	//    source: redhat-operators


### PR DESCRIPTION
Currently we are using the 'stable' channel which is somewhat
deprecated and is not getting any updates.
Now that we've dropped OCP 4.9 support [1][2] we can switch to the gitops-1.8
channel as the new default gitops version for patterns.
We also hold off releasing the new VP operator version (0.0.12) until
gitops-1.8.2 is released which fixes the login issue with our
name-spaced argo configuration.

Tested on an MCG deployment and correctly got gitops-1.8.1 installed.

[1] https://github.com/hybrid-cloud-patterns/utilities/pull/50
[2] https://github.com/hybrid-cloud-patterns/utilities/pull/51
