### PR TITLE
Switch imagePullPolicy to IfNotPresent

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -35,7 +35,7 @@ spec:
         name: manager
         securityContext:
           allowPrivilegeEscalation: false
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
No point in hammering registries and pulling the image all the time.

Tested on MCG
