### PR TITLE
ARM-based MacOS Development Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ testbin/*
 *.out
 
 # Kubernetes Generated files - skip generated files, except for vendored files
-
 !vendor/**/zz_generated.*
 
 # editor and IDE paraphernalia
@@ -24,3 +23,7 @@ testbin/*
 *.swo
 *~
 manager
+
+# Generated OLM catalog and template
+/catalog/catalog.yaml
+/catalog/_template.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ testbin/*
 *~
 manager
 
-# Generated OLM catalog and template
+# Catalog files generated for OLM testing
 /catalog/catalog.yaml
 /catalog/_template.yaml
+/config/samples/pattern-catalog-*.yaml

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,12 @@ BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
+# Override CONTAINER_PLATFORM and CONTAINER_OS to build for a different OS and
+# architecture. These should probably always be amd64/linux unless you're
+# running the container images on another OS or arch.
+CONTAINER_OS ?= linux
+CONTAINER_PLATFORM ?= amd64
+
 # IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.
 # This variable is used to construct full image tags for bundle and catalog images.
 #
@@ -114,7 +120,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build:  ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker build --platform $(CONTAINER_OS)/$(CONTAINER_PLATFORM) -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
@@ -182,12 +188,11 @@ bundle: manifests kustomize ## Generate bundle manifests and metadata, then vali
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	docker build --platform $(CONTAINER_OS)/$(CONTAINER_PLATFORM) -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
 	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
-
 
 .PHONY: csv-date
 csv-date: ## Set createdAt date in the CSV.
@@ -255,7 +260,6 @@ catalog-install: config/samples/pattern-catalog-$(VERSION).yaml
 config/samples/pattern-catalog-$(VERSION).yaml:
 	cp  config/samples/pattern-catalog.yaml config/samples/pattern-catalog-$(VERSION).yaml
 	sed -i -e "s@CATALOG_IMG@$(CATALOG_IMG)@g" config/samples/pattern-catalog-$(VERSION).yaml
-
 
 golangci-lint:
 	podman run --rm -v $(PWD):/app:rw,z -w /app golangci/golangci-lint:v1.46.2 golangci-lint run -v

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.19.1/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.26.5/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/README.md
+++ b/README.md
@@ -52,11 +52,12 @@ oc logs -npatterns-operator-system `oc get -npatterns-operator-system pods -o na
 
 ## Development
 
-### Test your changes (locally)
+### Test your changes locally against a remote cluster
 
-Run the operator on your local machine against a cluster's API.
+Run the operator on your machine from your local directory against a cluster's
+API.
 
-```
+```bash
 oc login
 oc apply -f ./config/crd/bases
 # For Linux amd64
@@ -65,11 +66,16 @@ make run
 GOOS=darwin GOARCH=arm64 make run
 ```
 
-### Test your changes (on cluster)
+#### Test your changes on a cluster (Maintainers only)
 
-Run the operator on an OpenShift cluster.
+Run the operator in a Pod on an OpenShift cluster. This will create a container
+image under the *hybridcloudpatterns* organization in Quay.
 
-```
+**NOTE:** This method only works for maintainers who have push access to the
+GitHub repository. To test changes in a forked repo, see *Test your changes on
+a cluster (Anyone)* below.
+
+```bash
 BRANCH=`whoami`
 git co -b $BRANCH
 vi somefile.go
@@ -79,11 +85,18 @@ git push --set-upstream origin $BRANCH
 VERSION=$BRANCH make deploy
 ```
 
-### Test your changes (alt)
+#### Test your changes on a cluster (Anyone)
 
-Replace $USER and the version of the operator:
+Run the operator in a Pod on an OpenShift cluster. This will create a container
+image under your user account in Quay.
 
-```
+**NOTE:** If you're doing this for the first time, the repo in Quay will be set
+to private. You will need to change the permission on the repo to public before
+running `make deploy`.
+
+Replace $USER and the version of the operator.
+
+```bash
 vi somefile.go
 export IMAGE_TAG_BASE=quay.io/$USER/patterns-operator
 export IMG=quay.io/$USER/patterns-operator:0.0.2
@@ -93,25 +106,50 @@ make deploy
 
 Restart the container to pick up the latest image from quay
 
-```
- oc delete pods -n patterns-operator-system --all; oc get pods -n patterns-operator-system -w
+```bash
+oc delete pods -n patterns-operator-system --all; oc get pods -n patterns-operator-system -w
 ```
 
-### Upgrade testing with OLM
+### Validating end-to-end installation and upgrade path with OLM
 
-Assuming the previous version was `0.0.1`, and we're not deploying to the official Quay repository, start by defining the version, creating the 3 images, and pushing them to quay:
+The patterns operator is distributed through OLM from the official
+[Community Operators](https://github.com/redhat-openshift-ecosystem/community-operators-prod)
+catalog. It is a good idea to end-to-end validate OLM bundle changes before
+releasing a new version.
+
+The commands below will generate an operator controller image, OLM bundle
+image, and OLM catalog image under your user account in Quay. The generated
+catalog can then be installed on an OpenShift cluster which will provide an
+option to install the candidate operator version from OperatorHub.
+
+**NOTE:** If you're doing this for the first time, the repos in Quay will be
+set to private. You will need to change the permission on the repos to public
+before running `make catalog-install`.
+
+Assuming the previous version was `0.0.1`, start by defining the version,
+creating the 3 images, and pushing them to quay:
 
 ```
-export VERSION=0.0.2
+export USER=replace-me  # Replace user
+export VERSION=0.0.2    # Replace version
 IMAGE_TAG_BASE=quay.io/$USER/patterns-operator CHANNELS=fast make docker-build docker-push bundle bundle-build bundle-push catalog-build catalog-push
 ```
 
-Now create the CatalogSource so the cluster can see the new version
+**NOTE:** If you run into errors with the `opm` command, upgrade your installed
+opm version. opm release [1.26.5](https://github.com/operator-framework/operator-registry/releases/tag/v1.26.5)
+or newer should be good.
+
+Now create the CatalogSource on your cluster:
 
 ```
 make catalog-install
 ```
 
+After ~60 seconds, the CatalogSource object should have the status *READY*. (It
+may briefly show the status *TRANSIENT_FAILURE* before showing *READY*.)
+
+In the OpenShift Console, navigate to OperarorHub. Search for *Patterns
+Operator*. Install the operator from the source *Test Patterns Operator*.
 
 ### Releases
 

--- a/catalog/Dockerfile
+++ b/catalog/Dockerfile
@@ -1,0 +1,15 @@
+# The base image is expected to contain
+# /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
+FROM quay.io/operator-framework/opm:latest
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+# Copy declarative config root into image at /configs and pre-populate serve cache
+ADD catalog.yaml /configs/catalog.yaml
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+# Set DC-specific label for the location of the DC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/catalog/template.yaml
+++ b/catalog/template.yaml
@@ -1,0 +1,42 @@
+# This catalog is used for testing OLM deployment outside of the OperatorHub
+# community catalog. You should only use this catalog for validating OLM
+# bundles and for testing OLM upgrades against an OpenShift cluster.
+#
+# $VERSION and $BUNDLE_IMG will be replaced by `make catalog-build`
+#
+# If you want to test upgrading, replace this file's contents with an
+# uncommented copy of this (replace bundle image and versions, can't do that
+# automatically):
+#
+# schema: olm.package
+# name: patterns-operator
+# defaultChannel: fast
+# ---
+# schema: olm.channel
+# package: patterns-operator
+# name: fast
+# entries:
+# # Old Version
+# - name: patterns-operator.v0.0.12
+# # New Version
+# - name: patterns-operator.v0.0.13
+#   replaces: patterns-operator.v0.0.12
+# ---
+# schema: olm.bundle
+# image: quay.io/youruser/patterns-operator-bundle:v0.0.12
+# ---
+# schema: olm.bundle
+# image: quay.io/youruser/patterns-operator-bundle:v0.0.13
+#
+schema: olm.package
+name: patterns-operator
+defaultChannel: fast
+---
+schema: olm.channel
+package: patterns-operator
+name: fast
+entries:
+- name: patterns-operator.v$VERSION
+---
+schema: olm.bundle
+image: $BUNDLE_IMG

--- a/config/samples/pattern-catalog.yaml
+++ b/config/samples/pattern-catalog.yaml
@@ -1,8 +1,9 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
-  name: pattern-index
+  name: test-pattern-operator
   namespace: openshift-marketplace
 spec:
+  displayName: Test Pattern Operator
   sourceType: grpc
   image: CATALOG_IMG


### PR DESCRIPTION
Here's two additional improvements I've made to get the development process outlined in README.md working on my Macbook.

## [Set --platform on container build make targets](https://github.com/hybrid-cloud-patterns/patterns-operator/commit/8d19b3f85e3804a60bdb51c783595846c002fbed)

On M1 Macs it will default to building a darwin/arm64 based image. That probably isn't what you want. If for some reason you do want that, there are two variables now to set for architecture and operating system.

## [Get make catalog-build working on ARM-based MacOS](https://github.com/hybrid-cloud-patterns/patterns-operator/commit/33e8f8258872bfeb0747e4a80b160ba23f199d07)

make catalog-build had issues on MacOS because it would try to build an darwin/arm64 container image when building the OLM catalog. Using the SQLite-based catalog commands, there is no way to set the platform of the container image that opm builds.

I converted the catalog-build process to use a file-based catalog instead of a SQLite-based catalog. That allows us to call docker (or podman) directly with the --platform tag.

(SQLite-based catalogs are deprecated so this would have to be done eventually anyways.)