### PR TITLE
Do not hardcode the CatalogSource

### DIFF
--- a/controllers/subscription.go
+++ b/controllers/subscription.go
@@ -55,7 +55,7 @@ func newSubscription(p api.Pattern) *operatorv1alpha1.Subscription {
 	//          value: "*"
 
 	spec := &operatorv1alpha1.SubscriptionSpec{
-		CatalogSource:          "redhat-operators",
+		CatalogSource:          p.Spec.GitOpsConfig.OperatorSource,
 		CatalogSourceNamespace: "openshift-marketplace",
 		Channel:                p.Spec.GitOpsConfig.OperatorChannel,
 		Package:                "openshift-gitops-operator",


### PR DESCRIPTION
Currently we hard code it to "redhat-operators". Let's
actually allow the user to override it via GitOpsConfig.OperatorSource
which already exists for exactly this purpose.

Tested as follows:
- Without the change editing the "Git Ops Spec" with a non existing
  "Operator Source" would still install the operator as usual from the
  redhat-operators catalog.

- With the change editing the "Git Ops Spec" with a non existing
  "Operator Source" would fail with:

  constraints not satisfiable: no operators found from catalog
  porca-zozza in namespace openshift-marketplace referenced by
  subscription openshift-gitops-operator, subscription
  openshift-gitops-operator exists

- With the change installing a pattern leaving all the defaults as is
  installed the operator as usual
