### PR TITLE
Make sure extraParams are passed down to all the applications

### DIFF
--- a/controllers/argo.go
+++ b/controllers/argo.go
@@ -114,6 +114,15 @@ func newApplicationValueFiles(p api.Pattern) []string {
 	return files
 }
 
+func newApplicationValues(p api.Pattern) string {
+	s := "extraParametersNested:\n"
+	for _, extra := range p.Spec.ExtraParameters {
+		line := fmt.Sprintf("  %s: %s\n", extra.Name, extra.Value)
+		s = s + line
+	}
+	return s
+}
+
 func newApplication(p api.Pattern) *argoapi.Application {
 
 	// Argo uses...
@@ -133,6 +142,8 @@ func newApplication(p api.Pattern) *argoapi.Application {
 				// Parameters is a list of Helm parameters which are passed to the helm template command upon manifest generation
 				Parameters: newApplicationParameters(p),
 
+				// This is to be able to pass down the extraParams to the single applications
+				Values: newApplicationValues(p),
 				// ReleaseName is the Helm release name to use. If omitted it will use the application name
 				// ReleaseName string `json:"releaseName,omitempty" protobuf:"bytes,3,opt,name=releaseName"`
 				// Values specifies Helm values to be passed to helm template, typically defined as a block


### PR DESCRIPTION
Currently when you pass extraParams like follows:
--set main.extraParameters[0].name=clusterGroup.subscriptions.acm.source
--set main.extraParameters[0].value=iib-${IIB}

These parameters make it to the main argo application installed into the
cluster-wide argocd instance. The problem is that these extraParams do
not make it to the applications that are created inside the namespaced
argocd instance. We fix this by injecting a list of key values pairs
inside a dictionary called "extraParametersNested" inside the "value"
field of the applications that get installed.

A corresponding change in common/ will unroll the key/value pairs under
extraParametersNested and pass them as parameters.

Testes this with:

  make EXTRA_HELM_OPTS="
    --set main.extraParameters[0].name=clusterGroup.subscriptions.acm.source
    --set main.extraParameters[0].value=iib-${IIB}
    --set main.extraParameters[1].name=clusterGroup.subscriptions.acm.channel
    --set main.extraParameters[1].value=${CHANNEL}" install

I correctly observed that the clusterGroup.subscriptions.acm.source
value made it all the way to the common/acm argo application.
