### PR TITLE
Switch to configV1 ClusterVersions to fetch the version of the cluster

### DIFF
--- a/controllers/pattern_controller.go
+++ b/controllers/pattern_controller.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/go-errors/errors"
 	"github.com/go-logr/logr"
 
@@ -313,19 +312,15 @@ func (r *PatternReconciler) applyDefaults(input *api.Pattern) (error, *api.Patte
 	}
 
 	// Cluster Version
-	// oc get OpenShiftControllerManager/cluster -o jsonpath='{.status.version}'
-	clusterVersion, err := r.operatorClient.OpenShiftControllerManagers().Get(context.Background(), "cluster", metav1.GetOptions{})
+	// oc get clusterversion/version -o yaml
+	clusterVersions, err := r.configClient.ConfigV1().ClusterVersions().Get(context.Background(), "version", metav1.GetOptions{})
 	if err != nil {
 		return err, output
 	} else {
-		// status:
-		//   ...
-		//   version: 4.10.32
-		v, version_err := semver.NewVersion(string(clusterVersion.Status.Version))
+		v, version_err := getCurrentClusterVersion(*clusterVersions)
 		if version_err != nil {
 			return version_err, output
 		}
-
 		output.Status.ClusterVersion = fmt.Sprintf("%d.%d", v.Major(), v.Minor())
 	}
 

--- a/controllers/pattern_controller_test.go
+++ b/controllers/pattern_controller_test.go
@@ -163,7 +163,18 @@ var _ = Describe("pattern controller", func() {
 
 func newFakeReconciler(initObjects ...runtime.Object) *PatternReconciler {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(initObjects...).Build()
-	clusterVersion := &v1.ClusterVersion{ObjectMeta: metav1.ObjectMeta{Name: "version"}, Spec: v1.ClusterVersionSpec{ClusterID: "10"}}
+	clusterVersion := &v1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{Name: "version"},
+		Spec:       v1.ClusterVersionSpec{ClusterID: "10"},
+		Status: v1.ClusterVersionStatus{
+			History: []v1.UpdateHistory{
+				{
+					State:   "Completed",
+					Version: "4.10.3",
+				},
+			},
+		},
+	}
 	clusterInfra := &v1.Infrastructure{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}, Spec: v1.InfrastructureSpec{PlatformSpec: v1.PlatformSpec{Type: "AWS"}}}
 	osControlManager := &operatorv1.OpenShiftControllerManager{
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -21,8 +21,11 @@ import (
 	"log"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	api "github.com/hybrid-cloud-patterns/patterns-operator/api/v1alpha1"
 	v1 "k8s.io/api/core/v1"
+
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 var (
@@ -110,4 +113,43 @@ func getPatternConditionByType(conditions []api.PatternCondition, conditionType 
 		}
 	}
 	return -1, nil
+}
+
+// status:
+//  history:
+//   - completionTime: null
+//     image: quay.io/openshift-release-dev/ocp-release@sha256:af19e94813478382e36ae1fa2ae7bbbff1f903dded6180f4eb0624afe6fc6cd4
+//     startedTime: "2023-07-18T07:48:54Z"
+//     state: Partial
+//     verified: true
+//     version: 4.13.5
+//   - completionTime: "2023-07-18T07:08:50Z"
+//     image: quay.io/openshift-release-dev/ocp-release@sha256:e3fb8ace9881ae5428ae7f0ac93a51e3daa71fa215b5299cd3209e134cadfc9c
+//     startedTime: "2023-07-18T06:48:44Z"
+//     state: Completed
+//     verified: false
+//     version: 4.13.4
+//   observedGeneration: 4
+//     version: 4.10.32
+
+// This function returns the current version of the cluster. Ideally
+// We return the first version with Completed status
+// https://pkg.go.dev/github.com/openshift/api/config/v1#ClusterVersionStatus specifies that the ordering is preserved
+// We do have a fallback in case the history does either not exist or it simply has never completed an update:
+// in such cases we just fallback to the status.desired.version
+func getCurrentClusterVersion(clusterversion configv1.ClusterVersion) (*semver.Version, error) {
+	for _, v := range clusterversion.Status.History {
+		if v.State == "Completed" {
+			s, version_err := semver.NewVersion(v.Version)
+			if version_err != nil {
+				return nil, version_err
+			}
+			return s, nil
+		}
+	}
+	s, version_err := semver.NewVersion(clusterversion.Status.Desired.Version)
+	if version_err != nil {
+		return nil, version_err
+	}
+	return s, nil
 }


### PR DESCRIPTION
The reason we used the equivalent of `oc get OpenShiftControllerManager/cluster -o jsonpath='{.status.version}'`
was that it was a very simple way to get the *current* version of the
cluster. Since certain deployed OCP clusters do not seem to have the
.status.version, we take the more complex route of parsing the status history
of `oc get clusterversion/version -o yaml`. These fields are always
present in all clusters and it is the same approach the UI is
implementing currently [1][2].

Furthermore the clusterVersionStatus docs at [3] specify the following:

	// desired is the version that the cluster is reconciling towards.
	// If the cluster is not yet fully initialized desired will be set
	// with the information available, which may be an image or a tag.
	// +kubebuilder:validation:Required
	// +required
	Desired Release `json:"desired"`

	// history contains a list of the most recent versions applied to the cluster.
	// This value may be empty during cluster startup, and then will be updated
	// when a new update is being applied. The newest update is first in the
	// list and it is ordered by recency. Updates in the history have state
	// Completed if the rollout completed - if an update was failing or halfway
	// applied the state will be Partial. Only a limited amount of update history
	// is preserved.
	// +optional

So what we do in this patch is to check the history and return the first
version in the history which has its state as completed. Should we not
find any (as it might happen during cluster initialization), we fall
back on returning the ClusterVersion.Status.Desired. This is only for
the les slikely case where the cluster still has not version history, in
such cases (and only in such cases), it seems to be okay to just fall
back to that.

Tested both on a ROSA 4.12.x deployed via ClusterBot (which did show the
issue about missing OpenShiftControllerManager/cluster.status.version
and on a stock 4.13 deployed via install-config.

[1] https://github.com/openshift/console/blob/master/frontend/public/module/k8s/cluster-settings.ts#L239
[2] https://github.com/openshift/console/blob/master/frontend/public/module/k8s/cluster-settings.ts#L247
[3] https://pkg.go.dev/github.com/openshift/api/config/v1#ClusterVersionStatus
