### PR TITLE
Introduce ordering in the UI in the gitSpec form

### DIFF
--- a/api/v1alpha1/pattern_types.go
+++ b/api/v1alpha1/pattern_types.go
@@ -74,33 +74,34 @@ type PatternSpec struct {
 }
 
 type GitConfig struct {
-	// Optional. FQDN of the git server if automatic parsing from TargetRepo is broken
-	Hostname string `json:"hostname,omitempty"`
-
 	//Account              string `json:"account,omitempty"`
 	//TokenSecret          string `json:"tokenSecret,omitempty"`
 	//TokenSecretNamespace string `json:"tokenSecretNamespace,omitempty"`
 	//TokenSecretKey       string `json:"tokenSecretKey,omitempty"`
 
-	// Upstream git repo containing the pattern to deploy. Used when in-cluster fork to point to the upstream pattern repository
-	//+operator-sdk:csv:customresourcedefinitions:type=spec
-	OriginRepo string `json:"originRepo,omitempty"`
-
-	// Branch, tag or commit in the upstream git repository. Does not support short-sha's. Default to HEAD
-	//+operator-sdk:csv:customresourcedefinitions:type=spec
-	OriginRevision string `json:"originRevision,omitempty"`
-
-	// Interval in seconds to poll for drifts between origin and target repositories. Default: 180 seconds
-	//+operator-sdk:csv:customresourcedefinitions:type=spec
-	PollInterval int `json:"pollInterval,omitempty"`
-
 	// Git repo containing the pattern to deploy. Must use https/http
-	//+operator-sdk:csv:customresourcedefinitions:type=spec
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=1
 	TargetRepo string `json:"targetRepo"`
 
 	// Branch, tag, or commit to deploy.  Does not support short-sha's. Default: HEAD
-	//+operator-sdk:csv:customresourcedefinitions:type=spec
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=2
 	TargetRevision string `json:"targetRevision,omitempty"`
+
+	// Upstream git repo containing the pattern to deploy. Used when in-cluster fork to point to the upstream pattern repository
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=3
+	OriginRepo string `json:"originRepo,omitempty"`
+
+	// Branch, tag or commit in the upstream git repository. Does not support short-sha's. Default to HEAD
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=4
+	OriginRevision string `json:"originRevision,omitempty"`
+
+	// Interval in seconds to poll for drifts between origin and target repositories. Default: 180 seconds
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=5
+	PollInterval int `json:"pollInterval,omitempty"`
+
+	// Optional. FQDN of the git server if automatic parsing from TargetRepo is broken
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,order=6
+	Hostname string `json:"hostname,omitempty"`
 }
 
 type ApplyChangeType string

--- a/bundle/manifests/patterns-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/patterns-operator.clusterserviceversion.yaml
@@ -22,9 +22,9 @@ metadata:
     capabilities: Basic Install
     categories: OpenShift Optional
     containerImage: quay.io/hybridcloudpatterns/patterns-operator:0.0.17
-    createdAt: 2023-07-18 22:49:29
+    createdAt: 2023-07-26 15:50:32
     description: An operator to deploy and manage architecture patterns from https://hybrid-cloud-patterns.io
-    operators.operatorframework.io/builder: operator-sdk-v1.28.1
+    operators.operatorframework.io/builder: operator-sdk-v1.30.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/hybrid-cloud-patterns/patterns-operator
   name: patterns-operator.v0.0.17
@@ -42,6 +42,29 @@ spec:
         name: patterns
         version: v1alpha1
       specDescriptors:
+      - description: Git repo containing the pattern to deploy. Must use https/http
+        displayName: Target Repo
+        path: gitSpec.targetRepo
+      - description: 'Branch, tag, or commit to deploy.  Does not support short-sha''s.
+          Default: HEAD'
+        displayName: Target Revision
+        path: gitSpec.targetRevision
+      - description: Upstream git repo containing the pattern to deploy. Used when
+          in-cluster fork to point to the upstream pattern repository
+        displayName: Origin Repo
+        path: gitSpec.originRepo
+      - description: Branch, tag or commit in the upstream git repository. Does not
+          support short-sha's. Default to HEAD
+        displayName: Origin Revision
+        path: gitSpec.originRevision
+      - description: 'Interval in seconds to poll for drifts between origin and target
+          repositories. Default: 180 seconds'
+        displayName: Poll Interval
+        path: gitSpec.pollInterval
+      - description: Optional. FQDN of the git server if automatic parsing from TargetRepo
+          is broken
+        displayName: Hostname
+        path: gitSpec.hostname
       - displayName: Cluster Group Name
         path: clusterGroupName
       - description: '.Name is dot separated per the helm --set syntax, such as: global.something.field'
@@ -75,25 +98,6 @@ spec:
           False'
         displayName: Use CSV
         path: gitOpsSpec.useCSV
-      - description: Upstream git repo containing the pattern to deploy. Used when
-          in-cluster fork to point to the upstream pattern repository
-        displayName: Origin Repo
-        path: gitSpec.originRepo
-      - description: Branch, tag or commit in the upstream git repository. Does not
-          support short-sha's. Default to HEAD
-        displayName: Origin Revision
-        path: gitSpec.originRevision
-      - description: 'Interval in seconds to poll for drifts between origin and target
-          repositories. Default: 180 seconds'
-        displayName: Poll Interval
-        path: gitSpec.pollInterval
-      - description: Git repo containing the pattern to deploy. Must use https/http
-        displayName: Target Repo
-        path: gitSpec.targetRepo
-      - description: 'Branch, tag, or commit to deploy.  Does not support short-sha''s.
-          Default: HEAD'
-        displayName: Target Revision
-        path: gitSpec.targetRevision
       statusDescriptors:
       - displayName: App Cluster Domain
         path: appClusterDomain

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: patterns-operator
   operators.operatorframework.io.bundle.channels.v1: fast
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.28.1
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.30.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/manifests/bases/patterns-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/patterns-operator.clusterserviceversion.yaml
@@ -23,6 +23,29 @@ spec:
         name: patterns
         version: v1alpha1
       specDescriptors:
+      - description: Git repo containing the pattern to deploy. Must use https/http
+        displayName: Target Repo
+        path: gitSpec.targetRepo
+      - description: 'Branch, tag, or commit to deploy.  Does not support short-sha''s.
+          Default: HEAD'
+        displayName: Target Revision
+        path: gitSpec.targetRevision
+      - description: Upstream git repo containing the pattern to deploy. Used when
+          in-cluster fork to point to the upstream pattern repository
+        displayName: Origin Repo
+        path: gitSpec.originRepo
+      - description: Branch, tag or commit in the upstream git repository. Does not
+          support short-sha's. Default to HEAD
+        displayName: Origin Revision
+        path: gitSpec.originRevision
+      - description: 'Interval in seconds to poll for drifts between origin and target
+          repositories. Default: 180 seconds'
+        displayName: Poll Interval
+        path: gitSpec.pollInterval
+      - description: Optional. FQDN of the git server if automatic parsing from TargetRepo
+          is broken
+        displayName: Hostname
+        path: gitSpec.hostname
       - displayName: Cluster Group Name
         path: clusterGroupName
       - description: '.Name is dot separated per the helm --set syntax, such as: global.something.field'
@@ -56,25 +79,6 @@ spec:
           False'
         displayName: Use CSV
         path: gitOpsSpec.useCSV
-      - description: Upstream git repo containing the pattern to deploy. Used when
-          in-cluster fork to point to the upstream pattern repository
-        displayName: Origin Repo
-        path: gitSpec.originRepo
-      - description: Branch, tag or commit in the upstream git repository. Does not
-          support short-sha's. Default to HEAD
-        displayName: Origin Revision
-        path: gitSpec.originRevision
-      - description: 'Interval in seconds to poll for drifts between origin and target
-          repositories. Default: 180 seconds'
-        displayName: Poll Interval
-        path: gitSpec.pollInterval
-      - description: Git repo containing the pattern to deploy. Must use https/http
-        displayName: Target Repo
-        path: gitSpec.targetRepo
-      - description: 'Branch, tag, or commit to deploy.  Does not support short-sha''s.
-          Default: HEAD'
-        displayName: Target Revision
-        path: gitSpec.targetRevision
       statusDescriptors:
       - displayName: App Cluster Domain
         path: appClusterDomain


### PR DESCRIPTION
Currently the ordering of the fields displayed in pattern's creation UI
is somewhat random (it depends on the path which is taken from the
JSON's field and it gets sorted alphabetically).
With operator-sdk version 1.30 a new =order field has been introduced [1][2] so
it is now possible to be explicit with the ordering when generating the
bundle via the operator-sdk.

So let's reorder the elements with the most important ones first.
Tested this and I correctly see the following order in the UI:

    Target Repo - Git repo containing the pattern to deploy. Must use https/http
    Target Revision - Branch, tag, or commit to deploy.  Does not support short-sha's. Default: HEAD
    Origin Repo - Upstream git repo containing the pattern to deploy. Used when in-cluster fork to point to the upstream pattern repository
    Origin Revision - Branch, tag or commit in the upstream git repository. Does not support short-sha's. Default to HEAD
    Poll Interval - Interval in seconds to poll for drifts between origin and target repositories. Default: 180 seconds
    Hostname - Optional. FQDN of the git server if automatic parsing from TargetRepo is broken

This now makes a lot more sense and it is a lot clearer.

[1] https://github.com/operator-framework/operator-sdk/commit/0e772903d7c9c9807579a7bdaba3497b1e99cb74
[2] https://sdk.operatorframework.io/docs/building-operators/golang/references/markers/#usage
