### PR TITLE
feat(gitSpec): add targetPath for subdir values

### DIFF
--- a/api/v1alpha1/pattern_types.go
+++ b/api/v1alpha1/pattern_types.go
@@ -100,6 +100,10 @@ type GitConfig struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=16
 	TargetRevision string `json:"targetRevision,omitempty"`
 
+	// Path within git repo where values files are located. Default: repository root
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=17
+	TargetPath string `json:"targetPath,omitempty"`
+
 	// Upstream git repo containing the pattern to deploy. Used when in-cluster fork to point to the upstream pattern repository.
 	// Takes precedence over TargetRepo
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,order=14,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:fieldDependency:gitSpec.inClusterGitServer:true"}

--- a/bundle/manifests/gitops.hybrid-cloud-patterns.io_patterns.yaml
+++ b/bundle/manifests/gitops.hybrid-cloud-patterns.io_patterns.yaml
@@ -1,9 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.4
-  creationTimestamp: null
   name: patterns.gitops.hybrid-cloud-patterns.io
 spec:
   group: gitops.hybrid-cloud-patterns.io
@@ -106,6 +106,10 @@ spec:
                   originRevision:
                     description: (DEPRECATED) Branch, tag or commit in the upstream
                       git repository. Does not support short-sha's. Default to HEAD
+                    type: string
+                  targetPath:
+                    description: 'Path within git repo where values files are located.
+                      Default: repository root'
                     type: string
                   targetRepo:
                     description: Git repo containing the pattern to deploy. Must use
@@ -241,9 +245,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: null
-  storedVersions: null

--- a/config/crd/bases/gitops.hybrid-cloud-patterns.io_patterns.yaml
+++ b/config/crd/bases/gitops.hybrid-cloud-patterns.io_patterns.yaml
@@ -107,6 +107,10 @@ spec:
                     description: (DEPRECATED) Branch, tag or commit in the upstream
                       git repository. Does not support short-sha's. Default to HEAD
                     type: string
+                  targetPath:
+                    description: 'Path within git repo where values files are located.
+                      Default: repository root'
+                    type: string
                   targetRepo:
                     description: Git repo containing the pattern to deploy. Must use
                       https/http or, for ssh, git@server:foo/bar.git

--- a/internal/controller/argo.go
+++ b/internal/controller/argo.go
@@ -370,6 +370,10 @@ func newApplicationParameters(p *api.Pattern) []argoapi.HelmParameter {
 			Value: p.Spec.GitConfig.TargetRevision,
 		},
 		{
+			Name:  "global.targetPath",
+			Value: p.Spec.GitConfig.TargetPath,
+		},
+		{
 			Name:  "global.hubClusterDomain",
 			Value: p.Status.AppClusterDomain,
 		},
@@ -457,6 +461,14 @@ func convertArgoHelmParametersToMap(params []argoapi.HelmParameter) map[string]a
 }
 
 func newApplicationValueFiles(p *api.Pattern, prefix string) []string {
+	basePath := p.Spec.GitConfig.TargetPath
+	if basePath != "" {
+		if prefix != "" {
+			prefix = fmt.Sprintf("%s/%s", prefix, basePath)
+		} else {
+			prefix = basePath
+		}
+	}
 	files := []string{
 		fmt.Sprintf("%s/values-global.yaml", prefix),
 		fmt.Sprintf("%s/values-%s.yaml", prefix, p.Spec.ClusterGroupName),
@@ -668,6 +680,7 @@ func newMultiSourceApplication(p *api.Pattern) *argoapi.Application {
 	valuesSource := &argoapi.ApplicationSource{
 		RepoURL:        p.Spec.GitConfig.TargetRepo,
 		TargetRevision: p.Spec.GitConfig.TargetRevision,
+		Path:           p.Spec.GitConfig.TargetPath,
 		Ref:            "patternref",
 	}
 	sources = append(sources, *valuesSource)


### PR DESCRIPTION
## Summary
- Add `targetPath` to GitConfig for specifying values file location
- Enables multiple envs in single repo (e.g. `envs/dev/`, `envs/prod/`)
- Non-breaking: empty default preserves existing behavior

## Changes
- Add `TargetPath` to GitConfig struct
- Prefix values files with targetPath
- Add Path to multi-source valuesSource
- Add `global.targetPath` helm param
- Add tests

## Test plan
- [x] `make test` passes
- [x] `make generate manifests` runs clean
- [ ] CI passes