### PR TITLE
Make sure the console uses any registry overrides

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -83,10 +83,10 @@ jobs:
       - name: Build console container image and save tarball
         env:
           TARGETARCH: ${{ matrix.targetarch }}
-          CONSOLE_PLUGIN_IMAGE: ${{ env.CONSOLE_NAME }}:${{ env.TAG }}
+          CONSOLE_PLUGIN_IMAGE_BASE: ${{ env.CONSOLE_NAME }}:${{ env.TAG }}
         run: |
           make "console-build-${TARGETARCH}"
-          buildah push "${CONSOLE_PLUGIN_IMAGE}-${TARGETARCH}" "docker-archive:/tmp/console-image-${TARGETARCH}.tar:${CONSOLE_PLUGIN_IMAGE}-${TARGETARCH}"
+          buildah push "${CONSOLE_PLUGIN_IMAGE_BASE}-${TARGETARCH}" "docker-archive:/tmp/console-image-${TARGETARCH}.tar:${CONSOLE_PLUGIN_IMAGE_BASE}-${TARGETARCH}"
 
       - name: Upload image artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -182,7 +182,7 @@ jobs:
         env:
           UPLOADREGISTRY: ${{ matrix.upload_registry }}
           OPERATOR_IMG: ${{ env.NAME }}:${{ env.TAG }}
-          CONSOLE_PLUGIN_IMAGE: ${{ env.CONSOLE_NAME }}:${{ env.TAG }}
+          CONSOLE_PLUGIN_IMAGE_BASE: ${{ env.CONSOLE_NAME }}:${{ env.TAG }}
         run: |
           make buildah-manifest
           buildah manifest add --arch=amd64 "${REGISTRY}/${OPERATOR_IMG}" "${REGISTRY}/${OPERATOR_IMG}-amd64"
@@ -191,10 +191,10 @@ jobs:
           DIGEST=$(skopeo inspect --format "{{.Digest}}" "docker://${UPLOADREGISTRY}/${OPERATOR_IMG}")
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
           make console-multiarch-manifest
-          buildah manifest add --arch=arm64 "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE}" "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE}-arm64"
-          buildah manifest add --arch=amd64 "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE}" "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE}-amd64"
+          buildah manifest add --arch=arm64 "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE_BASE}" "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE_BASE}-arm64"
+          buildah manifest add --arch=amd64 "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE_BASE}" "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE_BASE}-amd64"
           make console-push
-          CONSOLE_DIGEST=$(skopeo inspect --format "{{.Digest}}" "docker://${UPLOADREGISTRY}/${CONSOLE_PLUGIN_IMAGE}")
+          CONSOLE_DIGEST=$(skopeo inspect --format "{{.Digest}}" "docker://${UPLOADREGISTRY}/${CONSOLE_PLUGIN_IMAGE_BASE}")
           echo "console_digest=$CONSOLE_DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Install cosign
@@ -210,8 +210,8 @@ jobs:
           CONSOLE_DIGEST: ${{ steps.manifest-push.outputs.console_digest }}
           UPLOADREGISTRY: ${{ matrix.upload_registry }}
           OPERATOR_IMG: ${{ env.NAME }}:${{ env.TAG }}
-          CONSOLE_PLUGIN_IMAGE: ${{ env.CONSOLE_NAME }}:${{ env.TAG }}
+          CONSOLE_PLUGIN_IMAGE_BASE: ${{ env.CONSOLE_NAME }}:${{ env.TAG }}
         run: |
           cat "${XDG_RUNTIME_DIR}/containers/auth.json" > ~/.docker/config.json
           cosign sign --yes "${UPLOADREGISTRY}/${OPERATOR_IMG}@${DIGEST}"
-          cosign sign --yes "${UPLOADREGISTRY}/${CONSOLE_PLUGIN_IMAGE}@${CONSOLE_DIGEST}"
+          cosign sign --yes "${UPLOADREGISTRY}/${CONSOLE_PLUGIN_IMAGE_BASE}@${CONSOLE_DIGEST}"

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,8 @@ OPERATOR_IMG ?= $(OPERATOR_NAME)-operator:$(VERSION)
 
 # always release the console with the same tag as the operator and the other way around!
 # Image base URL of the console plugin
-CONSOLE_PLUGIN_IMAGE_BASE ?= $(OPERATOR_NAME)-operator-console
-export CONSOLE_PLUGIN_IMAGE ?= $(CONSOLE_PLUGIN_IMAGE_BASE):$(VERSION)
+CONSOLE_PLUGIN_IMAGE_BASE ?= $(OPERATOR_NAME)-operator-console:$(VERSION)
+export CONSOLE_PLUGIN_IMAGE ?= $(UPLOADREGISTRY)/$(CONSOLE_PLUGIN_IMAGE_BASE)
 CONSOLE_PLUGIN_DOCKERFILE ?= console-plugin.Dockerfile
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
@@ -409,25 +409,25 @@ generate-dockerfile-console-plugin:
 .PHONY: console-multiarch-manifest
 console-multiarch-manifest: ## creates the buildah manifest for multi-arch images
 	# The rm is needed due to bug https://www.github.com/containers/podman/issues/19757
-	buildah manifest rm "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE}" || /bin/true
-	buildah manifest create "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE}"
+	buildah manifest rm "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE_BASE}" || /bin/true
+	buildah manifest create "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE_BASE}"
 
 .PHONY: console-build-amd64
 console-build-amd64: generate-dockerfile-console-plugin console-multiarch-manifest ## build the console in amd64
 	@echo "Building the console amd64"
-	buildah build --platform linux/amd64 --format docker -f $(CONSOLE_PLUGIN_DOCKERFILE) -t "${CONSOLE_PLUGIN_IMAGE}-amd64"
-	buildah manifest add --arch=amd64 "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE}" "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE}-amd64"
+	buildah build --platform linux/amd64 --format docker -f $(CONSOLE_PLUGIN_DOCKERFILE) -t "${CONSOLE_PLUGIN_IMAGE_BASE}-amd64"
+	buildah manifest add --arch=amd64 "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE_BASE}" "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE_BASE}-amd64"
 
 .PHONY: console-build-arm64
 console-build-arm64: generate-dockerfile-console-plugin console-multiarch-manifest ## build the console in amd64
 	@echo "Building the console arm64"
-	buildah build --platform linux/arm64 --format docker -f $(CONSOLE_PLUGIN_DOCKERFILE) -t "${CONSOLE_PLUGIN_IMAGE}-arm64"
-	buildah manifest add --arch=arm64 "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE}" "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE}-arm64"
+	buildah build --platform linux/arm64 --format docker -f $(CONSOLE_PLUGIN_DOCKERFILE) -t "${CONSOLE_PLUGIN_IMAGE_BASE}-arm64"
+	buildah manifest add --arch=arm64 "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE_BASE}" "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE_BASE}-arm64"
 
 .PHONY: console-push
 console-push: ## Uploads the container to quay.io/validatedpatterns/${CONSOLE_PLUGIN_IMAGE}
-	@echo "Uploading the ${REGISTRY}/${CONSOLE_PLUGIN_IMAGE} container to ${UPLOADREGISTRY}/${CONSOLE_PLUGIN_IMAGE}"
-	buildah manifest push --all "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE}" "docker://${UPLOADREGISTRY}/${CONSOLE_PLUGIN_IMAGE}"
+	@echo "Uploading the ${REGISTRY}/${CONSOLE_PLUGIN_IMAGE_BASE} container to ${UPLOADREGISTRY}/${CONSOLE_PLUGIN_IMAGE_BASE}"
+	buildah manifest push --all "${REGISTRY}/${CONSOLE_PLUGIN_IMAGE_BASE}" "docker://${UPLOADREGISTRY}/${CONSOLE_PLUGIN_IMAGE_BASE}"
 
 .PHONY: console-integration-tests
 console-integration-tests: ## Run console integration tests (requires running cluster)


### PR DESCRIPTION
Previously when building the console it would point to the
patterns-operator-console:v1.2.3 image without the registry and
the deployment would fail.

Now we add the version to the CONSOLE_PLUGIN_IMAGE_BASE variable
and use that when building the console-* targets.

CONSOLE_PLUGIN_IMAGE is envsubsted in the console deployment yaml
and needs to container the registry (which can be overridden with
the UPLOADREGISTRY variable)
