### PR TITLE
Do not cache yaml

### DIFF
--- a/console/src/api.ts
+++ b/console/src/api.ts
@@ -13,7 +13,7 @@ const PATTERN_UI_CATALOG_BASE_URL = __PATTERN_UI_CATALOG_BASE_URL__ || DEFAULT_P
 
 
 async function fetchYAML<T>(url: string): Promise<T> {
-  const response = await consoleFetch(url);
+  const response = await consoleFetch(url, { cache: 'no-store' });
   const text = await response.text();
   return load(text) as T;
 }


### PR DESCRIPTION
Firefox aggressively caches fetch() responses and seems
to never refresh them even after force reloading.
Without this we will never see the new items in a new catalog
