### PR TITLE
Use the clustergroupname property from the catalog when available

### DIFF
--- a/console/src/components/InstallPatternPage.tsx
+++ b/console/src/components/InstallPatternPage.tsx
@@ -80,6 +80,7 @@ export default function InstallPatternPage() {
   const [targetRepo, setTargetRepo] = React.useState('');
   const [useOwnFork, setUseOwnFork] = React.useState(false);
   const [targetRevision, setTargetRevision] = React.useState('main');
+  const [clusterGroupName, setClusterGroupName] = React.useState('hub');
 
   const [secretTemplate, setSecretTemplate] = React.useState<SecretTemplate | null>(null);
   const [secretFormData, setSecretFormData] = React.useState<SecretFormData>({});
@@ -100,6 +101,7 @@ export default function InstallPatternPage() {
         });
 
         setPatternName(patternData.name);
+        setClusterGroupName(patternData.clustergroupname);
         setTargetRepo(patternData.repo_url || '');
         // Only use the template if it has actual secrets defined
         const hasSecrets = template && template.secrets && template.secrets.length > 0;
@@ -323,7 +325,7 @@ export default function InstallPatternPage() {
       const hasSecrets = secretFormData && Object.keys(secretFormData).length > 0 && secretTemplate;
       console.log('📊 [InstallPatternPage] Installation details:', {
         patternName,
-        clusterGroupName: 'hub',
+        clusterGroupName,
         targetRepo,
         targetRevision,
         hasSecrets,
@@ -346,7 +348,7 @@ export default function InstallPatternPage() {
           namespace: PATTERN_OPERATOR_NS,
         },
         spec: {
-          clusterGroupName: 'hub',
+          clusterGroupName: clusterGroupName,
           gitSpec: {
             targetRepo,
             targetRevision,

--- a/console/src/types.ts
+++ b/console/src/types.ts
@@ -33,19 +33,20 @@ export interface Pattern {
   name: string;
   pattern_version: string;
   display_name: string;
-  description?: string;
   repo_url: string;
-  docs_repo_url?: string;
   issues_url: string;
   docs_url: string;
   ci_url: string;
   tier: 'maintained' | 'tested' | 'sandbox';
   owners: string[];
+  org: string;
+  clustergroupname: string;
+  description?: string;
+  docs_repo_url?: string;
+  spoke?: unknown;
   requirements?: PatternRequirements;
   extra_features?: ExtraFeatures;
   external_requirements?: ExternalRequirements;
-  org: string;
-  spoke?: unknown;
   /** The catalog directory key used to fetch this pattern. */
   catalogKey?: string;
 }


### PR DESCRIPTION
Hardcoding it to hub won't work on a number of patterns

Co-Authored-By: Akos Eros <aeros@redhat.com>
