### PR TITLE
Drop vp-gitea routes permissions

### DIFF
--- a/internal/controller/pattern_controller.go
+++ b/internal/controller/pattern_controller.go
@@ -110,7 +110,6 @@ type PatternReconciler struct {
 //+kubebuilder:rbac:groups="operator.open-cluster-management.io",resources=multiclusterhubs,verbs=get;list
 //+kubebuilder:rbac:groups=operator.openshift.io,resources="openshiftcontrollermanagers",resources=openshiftcontrollermanagers,verbs=get;list
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;create;update;watch
-//+kubebuilder:rbac:groups="route.openshift.io",namespace=vp-gitea,resources=routes;routes/custom-host,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="view.open-cluster-management.io",resources=managedclusterviews,verbs=create
 //+kubebuilder:rbac:groups="cluster.open-cluster-management.io",resources=managedclusters,verbs=list;delete
 


### PR DESCRIPTION
We added those in the gitea helm chart 0.0.4 here
https://github.com/validatedpatterns/gitea-chart/commit/aba91ba695216fea56f7554b58c9033e9dc637eb

Tested on mcg + upstreamrepourl successfully
