### PR TITLE
Make cascade deletion optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Search OperatorHub for "pattern" and accept all the defaults
 ## Create the Multi-Cloud GitOps pattern
 
 ```
-kubectl create -f config/samples/gitops_v1alpha1_pattern.yaml
+oc create -f config/samples/gitops_v1alpha1_pattern.yaml
 ```
 
 ### Check the status
 
 ```
-kubectl get -f config/samples/gitops_v1alpha1_pattern.yaml -o yaml
+oc get -f config/samples/gitops_v1alpha1_pattern.yaml -o yaml
 oc get applications -A -w
 ```
 
@@ -36,20 +36,26 @@ secret and then add the secrets via the UI (this approach is a bit more work)
 ### Delete the pattern
 
 ```
-kubectl delete -f config/samples/gitops_v1alpha1_pattern.yaml
+oc delete -f config/samples/gitops_v1alpha1_pattern.yaml
 ```
 
-This will only remove the top-level application.
-The subscription and anything created by Argo will not be removed and canmust be removed manually.
-Removing the top-level application ensures that Argo won't try to put back anything you delete.
+This action removes the `Pattern` instance only.
 
-## Watch the logs
-
-When installing via UI the namespace will be `patterns-operator` (recommended)
+If you annotate the Pattern instance with `patterns.gitops.hybrid-cloud-patterns.io/prune: "true"`:
 
 ```
-oc logs -n patterns-operator `oc get -n patterns-operator pods -o name --field-selector status.phase=Running | grep patterns` -c manager -f
+oc annotate -f config/samples/gitops_v1alpha1_pattern.yaml patterns.gitops.hybrid-cloud-patterns.io/prune='true'
 ```
+
+Once the `Pattern` instance is deleted, the following resources will also be removed:
+
+- The top-level application of the hub cluster.
+- The child applications of the hub cluster.
+- The top-level application of the spoke clusters.
+- The child applications of the spoke clusters.
+- The `ManagedCluster` instances (excluding the `local-cluster`).
+
+**NOTE:** The GitOps Operator `Subscription` and the main `ArgoCD` instance will not be removed and must be removed manually.
 
 ## Development
 

--- a/internal/controller/pattern_controller.go
+++ b/internal/controller/pattern_controller.go
@@ -67,6 +67,7 @@ import (
 )
 
 const ReconcileLoopRequeueTime = 180 * time.Second
+const PruneAnnotation = "patterns.gitops.hybrid-cloud-patterns.io/prune"
 
 // PatternReconciler reconciles a Pattern object
 type PatternReconciler struct {
@@ -740,11 +741,11 @@ func (r *PatternReconciler) deleteHubApps(targetApp, app *argoapi.Application, n
 }
 
 func (r *PatternReconciler) finalizeObject(instance *api.Pattern) error {
-	// Add finalizer when object is created
 	log.Printf("Finalizing pattern object")
 
-	// The object is being deleted
-	if controllerutil.ContainsFinalizer(instance, api.PatternFinalizer) || controllerutil.ContainsFinalizer(instance, metav1.FinalizerOrphanDependents) {
+	// The object is being deleted and, if prune is enabled, we want to delete all the dependent objects in cascade
+	if strings.EqualFold(instance.Annotations[PruneAnnotation], "true") &&
+		(controllerutil.ContainsFinalizer(instance, api.PatternFinalizer) || controllerutil.ContainsFinalizer(instance, metav1.FinalizerOrphanDependents)) {
 		// Prepare the app for cascaded deletion
 		qualifiedInstance, err := r.applyDefaults(instance)
 		if err != nil {


### PR DESCRIPTION
Currently, when the `Pattern` CR is being deleted, the operator performs a cascade deletion of all ArgoCD `Applications` and their content (overriding the apps pruning configuration), and all `ManagedClusters` resources, eventually removing the entire `Hub` and `ManagedClusters` custom configurations, and detaching (and potentially deleting) all Openshift managed clusters.

This is a very dangerous behaviour.

For this reason this PR makes this behaviour configurable via the `gitops.enableCascadeDeletion` parameter in the `patterns-operator-config` `ConfigMap`. For a safe and conservative approach, the parameter defaults to `false`. If the user wants to actually perform cascade deletion, he can just set the parameter to `true` before deleting the `Pattern` instance.